### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 It handles UUIDs/GUIDs, integer identifiers and custom IDs with regular grammar. It also does TOTPs (time-based one time passwords), because that's vaguely related, fits the API and makes the name kind of a pun. Oh, and it generates incoherent nonsense too, if that's your thing.
 
-##Why?
+## Why?
 
 Because fumbling with identifiers and encodings, despite the extensive standard library, is a tedious, somewhat error-prone process that eventually tends to fill a code base with spaghetti. Also, random IDs like "SoppyClownGallopsAimlessly" are a *lot* more fun than using AUTO_INCREMENT.
 
 
-##Install
+## Install
 Grab the package with: 
 
     $ go get github.com/Sam-Izdat/kee
@@ -19,7 +19,7 @@ Grab the package with:
 [![License MIT](http://img.shields.io/badge/license-MIT-red.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![GoDoc](http://img.shields.io/badge/doc-REFERENCE-blue.svg?style=flat-square)](https://godoc.org/github.com/Sam-Izdat/kee)
 
-##Basic usage
+## Basic usage
 
 ```go
 package main
@@ -38,11 +38,11 @@ func main() {
 }
 ```
 
-##Making it useful
+## Making it useful
 
 But wait, there's more...
 
-###The universal and the global
+### The universal and the global
 
 ```go
 // Get a random UUID
@@ -80,7 +80,7 @@ The `Decode` method of the UUID handler accepts any valid string output listed a
 
 See documentation or source for UUIDs other than Version 4.
 
-###The less cosmopolitan identifiers
+### The less cosmopolitan identifiers
 
 ```go
 // Make a fixed precision integer identifier
@@ -113,7 +113,7 @@ Available methods for APIID output are: `Slc`, `BigInt`, and `B58`.
 
 The `Decode` method of the FPIID/APIID handlers accepts any valid string output listed above.
 
-###SplendidToucanVanishDarkly
+### SplendidToucanVanishDarkly
 
 ```go
 // ScrawlyFittersFlounderWhither
@@ -131,7 +131,7 @@ fmt.Println(wut, wut.SampleSpace())
 ```
 FatiguedPhalangeTriggingBackward? InboundClaptrapPreludesNudely.
 
-###Multi-factor authentication
+### Multi-factor authentication
 
 ```go
 // Generate a secret
@@ -161,7 +161,7 @@ openSafe := kee.TOTP.MatchPasswords(expected, received)
 ```
 This is generally intended for mobile devices and works with the [Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en) application.
 
-##Advanced usage
+## Advanced usage
 
 An ID instance comes from the handler of its respective type:
 - `UUID` for *Universally/Globally Unique Identifiers*
@@ -286,11 +286,11 @@ What's provided is really just scaffolding for anyone wishing to follow the conv
 - Some JUMBLE words are quite long. If storing phrases in a database, allow for at least 100 characters. Unless words are omitted, the sample space is usually very large but still well below a UUID; checking for collisions is a good idea.
 - Please, dear god, don't try to parse email addresses with regular expressions. You have been warned.
 
-#What still needs doin'
+# What still needs doin'
 - Complete unit tests
 - Some base set of built-in regular expressions for parsing common identifiers
 
-#Attributions
+# Attributions
 Code or content anonymously pinched from:
 
 - Tommi Virtanen: [base58](https://github.com/tv42/base58)
@@ -299,6 +299,6 @@ Code or content anonymously pinched from:
 - Ashley Bovan: [word lists](http://www.ashley-bovan.co.uk/words/partsofspeech.html)
 - [WPZOOM](http://www.wpzoom.com/): key icon used above (Attribution-Share Alike 3.0)
 
-#License
+# License
 
 MIT with some BSD-licensed snippets

--- a/doc/apiid.md
+++ b/doc/apiid.md
@@ -1,11 +1,11 @@
-##Arbitrary Precision Integer Identifiers
+## Arbitrary Precision Integer Identifiers
 APIIDs can be positive integers of any size and are represented as base 10 or base 58 strings and `big.Int` only. They can be:
 
 - Byte slice
 - `big.Int` integer (from "math/big" of the standard library)
 - Base 58 string
 
-###Generating from integer
+### Generating from integer
 ```go
     id1 := kee.APIID.FromString("12345678901234567890123456789")
         // ... OR:
@@ -16,12 +16,12 @@ APIIDs can be positive integers of any size and are represented as base 10 or ba
 
     fmt.Println(id1, "&", id3) // => KEm5phz2fXwaGwm6 & 4ER
 ```
-###Setting bytes
+### Setting bytes
 ```go
     // Must be slice
     id := kee.APIID.Set([]byte{11, 22, 33, 44}) // 185999660
 ```
-###Encoding
+### Encoding
 ```go
     fmt.Println(id)                     // Base 58
     fmt.Println(id.B58())               //   "
@@ -29,11 +29,11 @@ APIIDs can be positive integers of any size and are represented as base 10 or ba
     fmt.Println(id.BigInt().String())   // String
     fmt.Println(id.Slc())               // Slice
 ```
-###Decoding
+### Decoding
 ```go
     id := kee.APIID.Decode("hridG") // 185999660
 ```
-###Options
+### Options
 ```
     Cache: true            // Cache APIID strings, ignore new options
 ```

--- a/doc/fpiid.md
+++ b/doc/fpiid.md
@@ -1,4 +1,4 @@
-##Fixed Precision Integer Identifiers
+## Fixed Precision Integer Identifiers
 FPIIDs accept only unsigned 64 bit integers but, by default, they are converted to 32 or 16 bits whenever possible *for the purposes of base 64/32 string encoding*. This can be disabled by setting the `ShortStr` option to `false`. Slices, arrays and integers will always return as 8 bytes. FPIIDs can be represented as:
 
 - Byte slice/array
@@ -6,7 +6,7 @@ FPIIDs accept only unsigned 64 bit integers but, by default, they are converted 
 - Base 64 / URL-safe base 64 string
 - Base 32 / URL-safe base 32 string
 
-###Generating from integer
+### Generating from integer
 ```go
     id1 := kee.FPIID.New(555555555555555)
         // ...OR:
@@ -16,11 +16,11 @@ FPIIDs accept only unsigned 64 bit integers but, by default, they are converted 
     // String method defaults to URL-safe base 64
     fmt.Println(id1, "&", id2) // => 47iKW0b5AQA & OTA
 ```
-###Setting bytes
+### Setting bytes
 ```go
     id := kee.FPIID.Set([8]byte{255, 255, 255, 255, 255, 255, 255, 255})
 ```
-###Encoding
+### Encoding
 ```go
     fmt.Println(id.Int())       // Unsigned 64 bit int
     fmt.Println(id.B64())       // Base 64
@@ -31,12 +31,12 @@ FPIIDs accept only unsigned 64 bit integers but, by default, they are converted 
     fmt.Println(id.Slc())       // Slice
     fmt.Println(id.Arr())       // Array
 ```
-###Decoding
+### Decoding
 ```go
     id1 := kee.FPIID.Decode("4O4I-UW2G-7EAQ-A")  // dashes allowed
     id2 := kee.FPIID.Decode("sct0AA==")          // padding optional
 ```
-###Options
+### Options
 ```
     Cache: true            // Cache FPIID strings, ignore new options
     ShortStr: true         // Try conversion to uint32/16 for strings

--- a/doc/totb.md
+++ b/doc/totb.md
@@ -1,8 +1,8 @@
 
-##Time-based One Time Passwords
+## Time-based One Time Passwords
 Time-based one time passwords (RFC 6238) have gotten some traction for multi-factor authentication with the "Google Authenticator" mobile app. Reviewing the RFC for a secure implementation is highly recommended, but this might make it easier.
 
-###Options
+### Options
     LookAhead: 1           // Allow passwords from n future 30-second blocks
     LookBehind: 1          // Allow passwords from n previous 30-second blocks
     B32Blocks: 8           // Secret length (change will invalidate stored pws)

--- a/doc/uuid.md
+++ b/doc/uuid.md
@@ -1,4 +1,4 @@
-##UUIDs/GUIDs
+## UUIDs/GUIDs
 UUIDs, as described by RFC 4122, can be represented as:
 - Byte slice/array
 - Canonical hexadecimal string
@@ -17,7 +17,7 @@ Conversion functions are methods of the `kee.KUUID` type, returned when a UUID i
 - `func UUID.Set(arr [16]byte) (KUUID, error)`
 - `func UUID.Decode(s string) (KUUID, error)`
 
-###Generating
+### Generating
 There are several ways to create UUIDs and different versions serve somewhat different purposes. If in doubt, stick with Version 4. Take a look at [IETF's RFC](http://www.ietf.org/rfc/rfc4122.txt) for complete details.
 ```go
     // Version 4 (Random) UUID  -- most common version
@@ -39,12 +39,12 @@ There are several ways to create UUIDs and different versions serve somewhat dif
     // Version 5 (SHA1) UUID (much like V3)
     idv5 := kee.UUID.NewV5(domain1, data)
 ```
-###Setting bytes
+### Setting bytes
 ```go
     bytes := [16]byte{96, 109, 186, 97, 248, 73, 72, 5, 155, 122, 167, 157, 88, 212, 217, 94}
     id, err := kee.UUID.Set(bytes)
 ```
-###Encoding
+### Encoding
 Encoding is straightforward. Different encodings have different advantages and drawbacks.
 ```go
     // Print hex
@@ -69,7 +69,7 @@ Encoding is straightforward. Different encodings have different advantages and d
     fmt.Println(id.Slc())
     fmt.Println(id.Arr()) 
 ```
-###Decoding
+### Decoding
 Any string generated can be decoded, whatever the encoding. Checking the error value instead of ignoring it with an underscore is advised.
 ```go
     id1, _ := kee.UUID.Decode("urn:uuid:4769491a-7237-4e06-a60a-cc3098563df1")
@@ -82,7 +82,7 @@ Any string generated can be decoded, whatever the encoding. Checking the error v
     fmt.Println(id3, id4)
     // => 4769491a-7237-4e06-a60a-cc3098563df1 4769491a-7237-4e06-a60a-cc3098563df1
 ```
-###Options
+### Options
 Options can be set with  `kee.UUID.Options`, e.g.
 
 ```go


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
